### PR TITLE
Pin version to 2.13.33

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,14 +11,21 @@ function indent() {
   esac
 }
 
-AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+AWS_CLI_VERSION="2.13.33"
+
+if [ -n "${AWS_CLI_VERSION+x}" ]; then
+  echo "-----> AWS CLI version pinned to ${AWS_CLI_VERSION}"
+  AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip"
+else
+  AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+fi
 
 BUILD_DIR=$1
 BUILDPACK_DIR="$(dirname $(dirname $0))"
 INSTALL_DIR="/app/.awscli"
 TMP_DIR=$(mktemp -d)
 
-echo "-----> Downloading AWS CLI"
+echo "-----> Downloading AWS CLI ${AWS_CLI_URL}"
 curl --silent --show-error --fail -o "${TMP_DIR}/awscliv2.zip" "${AWS_CLI_URL}" |& indent
 unzip -qq -d "${TMP_DIR}" "${TMP_DIR}/awscliv2.zip" |& indent
 


### PR DESCRIPTION
Upstream issue: https://github.com/heroku/heroku-buildpack-awscli/issues/19

---

This branch avoids compile errors on the latest AWS CLI release that [cause deploys to fail](https://dashboard.heroku.com/apps/methodology-staging/activity/builds/d72ddd80-1fbe-48a0-badd-1eadc29e1fee):

<details>
  <summary>💥</summary>


```
-----> Building on the Heroku-20 stack
-----> Deleting 6 files matching .slugignore patterns.
-----> Using buildpacks:
       1. heroku/nodejs
       2. https://github.com/jayzes/heroku-buildpack-pngquant
       3. https://github.com/jayzes/heroku-buildpack-jpegoptim
       4. https://github.com/jayzes/heroku-buildpack-optipng
       5. heroku-community/awscli
       6. heroku-community/cli
       7. heroku/ruby
       8. https://github.com/Lostmyname/heroku-buildpack-post-build-clean.git
-----> Node.js app detected
       
-----> Creating runtime environment
       
       NPM_CONFIG_PRODUCTION=true
       NPM_CONFIG_LOGLEVEL=error
       YARN_PRODUCTION=true
       NODE_VERBOSE=false
       NODE_ENV=production
       NODE_MODULES_CACHE=true
       
-----> Installing binaries
       engines.node (package.json):  14.x
       engines.npm (package.json):   unspecified (use default)
       
       Resolving node version 14.x...
       Downloading and installing node 14.21.3...
       Using default npm version: 6.14.18
       
-----> Restoring cache
       - node_modules
       
-----> Installing dependencies
       Installing node modules (package.json)
       audited 738 packages in 3.731s
       
       56 packages are looking for funding
         run `npm fund` for details
       
       found 50 vulnerabilities (43 moderate, 7 critical)
         run `npm audit fix` to fix them, or `npm audit` for details
       
-----> Build
       
-----> Caching build
       - node_modules
       
-----> Pruning devDependencies
       Skipping because NPM_CONFIG_PRODUCTION is 'true'
       
-----> Build succeeded!
-----> pngquant app detected
-----> Installing pngquant
       PNGQUANT_DOWNLOAD_URL =  https://github.com/jayzes/heroku-buildpack-pngquant/releases/download/v2.0.1/pngquant
       exporting PATH
-----> jpegoptim app detected
-----> Using cached jpegoptim binary
-----> Testing jpegoptim binary
       jpegoptim v1.4.1  x86_64-unknown-linux-gnu
       Copyright (c) 1996-2014  Timo Kokkonen.
       
       libjpeg version: 8d  15-Jan-2012
       Copyright (C) 1991-2019 The libjpeg-turbo Project and many others
-----> Modifying PATH
-----> optipng app detected
-----> Installing optipng
       OPTIPNG_DOWNLOAD_URL =  https://github.com/jayzes/heroku-buildpack-optipng/releases/download/v0.7.4/optipng
       exporting PATH
-----> AWS CLI app detected
-----> Downloading AWS CLI
-----> Installing AWS CLI
       Fatal error condition occurred in /tmp/pip-install-90cp_aq0/awscrt_d52d3579cb5e4eb1a9ee6f8f288622f3/crt/aws-c-common/source/allocator.c:187: num != 0 && size != 0
       Exiting Application
       ################################################################################
       Stack trace:
       ################################################################################
       /tmp/tmp.1iydPa6t8R/aws/dist/_awscrt.abi3.so(aws_backtrace_print+0x4d) [0x7fcf0905fe6d]
       /tmp/tmp.1iydPa6t8R/aws/dist/_awscrt.abi3.so(aws_fatal_assert+0x44) [0x7fcf09053cc4]
       /tmp/tmp.1iydPa6t8R/aws/dist/_awscrt.abi3.so(aws_mem_calloc+0xee) [0x7fcf09052f7e]
       /tmp/tmp.1iydPa6t8R/aws/dist/_awscrt.abi3.so(aws_s3_platform_info_loader_new+0x88) [0x7fcf08fa95f8]
       /tmp/tmp.1iydPa6t8R/aws/dist/_awscrt.abi3.so(aws_s3_library_init+0x52) [0x7fcf08fa0d52]
       /tmp/tmp.1iydPa6t8R/aws/dist/_awscrt.abi3.so(PyInit__awscrt+0x10b) [0x7fcf08f9800b]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2ac245) [0x7fcf0f693245]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2a8141) [0x7fcf0f68f141]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x1bf310) [0x7fcf0f5a6310]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7fcf0f550b9d]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7fcf0f4eef6c]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x274998) [0x7fcf0f65b998]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x1bf0a1) [0x7fcf0f5a60a1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7fcf0f550b9d]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7fcf0f4eef6c]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x2dc) [0x7fcf0f691dec]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fcf0f65d1c4]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fcf0f4edb8e]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fcf0f662415]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fcf0f5516f0]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fcf0f5518ca]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fcf0f6920c1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fcf0f4f1ec1]
       /tmp/tmp.1iydPa6t8R/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fcf0f6622a5]
       /tmp/tmp.1iydPa6t8R/aws/dist/aws() [0x40332d]
       /tmp/tmp.1iydPa6t8R/aws/dist/aws() [0x403675]
       /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fcf0fbf5083]
       /tmp/tmp.1iydPa6t8R/aws/dist/aws() [0x401d11]
       Aborted
       You can now run: /app/.awscli/bin/aws --version
       Fatal error condition occurred in /tmp/pip-install-90cp_aq0/awscrt_d52d3579cb5e4eb1a9ee6f8f288622f3/crt/aws-c-common/source/allocator.c:187: num != 0 && size != 0
       Exiting Application
       ################################################################################
       Stack trace:
       ################################################################################
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_backtrace_print+0x4d) [0x7f93513c0e6d]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_fatal_assert+0x44) [0x7f93513b4cc4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_mem_calloc+0xee) [0x7f93513b3f7e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_s3_platform_info_loader_new+0x88) [0x7f935130a5f8]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_s3_library_init+0x52) [0x7f9351301d52]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(PyInit__awscrt+0x10b) [0x7f93512f900b]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2ac245) [0x7f93579f4245]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2a8141) [0x7f93579f0141]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x1bf310) [0x7f9357907310]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7f93578b1b9d]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7f935784ff6c]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x274998) [0x7f93579bc998]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x1bf0a1) [0x7f93579070a1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7f93578b1b9d]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7f935784ff6c]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x2dc) [0x7f93579f2dec]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7f93579be1c4]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7f935784eb8e]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7f93579c3415]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7f93578b26f0]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7f93578b28ca]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7f93579f30c1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7f9357852ec1]
       /tmp/build_4bf33829/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7f93579c32a5]
       /app/.awscli/bin/aws() [0x40332d]
       /app/.awscli/bin/aws() [0x403675]
       /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7f9357f56083]
       /app/.awscli/bin/aws() [0x401d11]
/tmp/codon/tmp/buildpacks/7284ab0946b858eb82845ccd21082133774b65f9/bin/compile: line 41:  1583 Aborted                 /app/.awscli/bin/aws --version 2>&1
      1584 Done                    | indent
 !     Push rejected, failed to compile AWS CLI app.
 !     Push failed
 ```

</details>

---

### References:

https://github.com/statushero/heroku-buildpack-awscli/pull/1
https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html
https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
https://statushero.slack.com/archives/C03FDQZVCJV/p1699644941671709

---

Buildpack URL:
[pin-cli-2.13.33](https://github.com/MethodologyDev/heroku-buildpack-awscli/tree/pin-cli-2.13.33)
```
https://github.com/MethodologyDev/heroku-buildpack-awscli.git#pin-cli-2.13.33
```